### PR TITLE
Implement Start Tracking Functionality

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftCuckoo",
+    platforms: [.macOS(.v10_15), .iOS(.v13)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SwiftCuckoo is a time-tracking tool designed specifically for Swift developers t
 - [ ] **Start & Stop Tracking**: Ability to start and stop time tracking for tasks.
 - [ ] **Lap Tracking**: Support for recording lap intervals to document different phases of a task.
 - [ ] **Real-time Task Consultation**: Ability to check any task tracked at any moment.
-- [ ] **Change Notifications**: Notify users when a time track changes. It should ppply observer for specific tasks.
+- [ ] **Change Notifications**: Notify users when a time track changes. It should apply observer for specific tasks.
 - [ ] **Data Storage**: Option to save specific task to time tracking data for future reference.
 - [ ] **Export & Report**: Functionality to export tracked time data for reporting purposes. (csv or json)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ SwiftCuckoo is a time-tracking tool designed specifically for Swift developers t
 
 *Instructions on how to install and set up the project will go here.*
 
+## Platforms
+
+- macOS 10.15+
+- iOS 13.0+
+
+These are the minimum platform versions required to run SwiftCuckoo.
+
 ## Usage
 
 *Instructions on how to use the tool will go here, including examples and code snippets if necessary.*

--- a/Sources/SwiftCuckoo/Session.swift
+++ b/Sources/SwiftCuckoo/Session.swift
@@ -2,37 +2,74 @@ import Foundation
 
 /// A model representing a session for time tracking in the SwiftCuckoo application.
 ///
-/// The `Session` structure is designed to encapsulate the details of a task that
-/// includes its start time, optional end time, and the duration calculated
-/// from these timestamps. This structure aids in managing and reporting
-/// the time spent on various tasks, providing valuable insights for users
-/// looking to optimize their productivity.
+/// The `Session` structure encapsulates the details of a task, including its start
+/// time, optional end time, and the duration calculated from these timestamps.
+/// This structure aids in managing and reporting the time spent on various tasks,
+/// providing valuable insights for users looking to optimize their productivity.
 public struct Session: Equatable, Hashable {
+    
+    /// Defines the possible validation errors for a `Session`.
+    public enum Invalid: Equatable {
+        case startTimeInFuture  /// Indicates the start time is set in the future.
+        case unknown             /// Represents an unknown error state.
+    }
+    
+    /// Defines the possible states of a `Session`.
+    public enum Status: Equatable {
+        case idle                /// Indicates the session is not currently active.
+        case running             /// Indicates the session is currently in progress.
+        case completed           /// Indicates the session has completed.
+        case invalid(Invalid)    /// Indicates the session has an invalid state with a specific reason.
+    }
+    
     /// A unique identifier for the session instance.
     public var id: Identifier
     
     /// The start time of the session. This indicates when the session began.
-    public var startTime: Date
+    public var startTime: Date?
     
     /// The optional end time of the session. This indicates when the session
     /// was completed or could still be ongoing.
     public var endTime: Date?
 
-    /// Initializes a new session instance with a unique identifier, a start
-    /// time, and an optional end time.
+    /// Initializes a new session instance with a unique identifier and an optional start time.
     ///
     /// - Parameters:
-    ///   - id: A unique identifier for the session. This helps in managing
-    ///          and tracking individual session instances.
-    ///   - startTime: The starting time of the session, indicating when it begins.
-    ///   - endTime: The end time of the session, representing when the session is
-    ///              completed. This parameter is optional and defaults to nil for ongoing sessions.
+    ///   - id: A unique identifier for the session, aiding in tracking individual sessions.
+    ///   - startTime: The starting time of the session, indicating when it begins. Defaults to nil.
+    ///   - endTime: The end time of the session. This parameter is optional and defaults to nil.
     ///
-    /// - Note: Ensure that the `endTime` is provided if the session is completed.
-    package init(id: Identifier, startTime: Date, endTime: Date? = nil) {
+    /// - Note: Ensure that `endTime` is provided if the session is completed.
+    public init(id: Identifier) {
         self.id = id
-        self.startTime = startTime
-        self.endTime = endTime
+        self.startTime = nil
+        self.endTime = nil
+    }
+    
+    /// Starts the session at the specified date.
+    ///
+    /// - Parameter date: The date to start the session. Defaults to the current date.
+    /// - Throws: An error of type `Error` if:
+    ///   - The session is already running (cannot start twice).
+    public mutating func start(on date: Date = Date()) throws {
+        guard status() == .idle else {
+            throw Error.cannotStartTwice
+        }
+        
+        self.startTime = date
+    }
+    
+    /// Stops the session at the specified date.
+    ///
+    /// - Parameter date: The date to stop the session. Defaults to the current date.
+    /// - Throws: An error of type `Error` if:
+    ///   - The session has not been started (must start before stopping).
+    public mutating func stop(on date: Date = Date()) throws {
+        guard status() == .running else {
+            throw Error.shouldStartSession
+        }
+        
+        self.endTime = date
     }
     
     /// Calculates the duration of the session.
@@ -44,15 +81,39 @@ public struct Session: Equatable, Hashable {
     /// - Returns: The duration of the session as a `TimeInterval` representing
     ///   the time spent from the start time to the end time.
     public func duration() throws -> TimeInterval {
-        guard let endTime else {
-            throw Error.missingEndTime
+        guard let startTime else {
+            throw Error.shouldStartSession
         }
         
-        guard endTime >= startTime else {
-            throw Error.endTimeBeforeStartTime
+        guard let endTime else {
+            throw Error.shouldStopSession
+        }
+        
+        guard self.status() == .completed else {
+            throw Error.invalidStartAndEndTimes
         }
         
         return endTime.timeIntervalSince(startTime)
+    }
+    
+    /// Determines the current status of the session.
+    ///
+    /// - Returns: The current status as a `Status` enumerator indicating whether
+    ///   the session is idle, running, completed, or invalid.
+    public func status() -> Status {
+        guard let startTime else {
+            return .idle
+        }
+        
+        guard let endTime else {
+            return .running
+        }
+        
+        guard startTime.compare(endTime) != .orderedDescending else {
+            return .invalid(.startTimeInFuture)
+        }
+        
+        return .completed
     }
 }
 
@@ -65,7 +126,7 @@ extension Session {
         /// The raw string value representing the identifier.
         public let rawValue: String
         
-        /// Initializes a new identifier with a given raw value.
+        /// Initializes a new identifier with the specified raw value.
         ///
         /// - Parameter rawValue: The string value that represents the identifier.
         public init(rawValue: String) {
@@ -78,13 +139,11 @@ extension Session {
 
 extension Session {
     /// Error types specific to the `Session` structure, conforming to `CustomNSError`,
-    /// used for error handling during duration calculations.
+    /// used for error handling during duration calculations and session state management.
     public enum Error: CustomNSError {
-        /// Indicates that the end time is missing, required for duration calculation.
-        case missingEndTime
-        
-        /// Indicates that the end time is set earlier than the start time,
-        /// leading to an invalid duration result.
-        case endTimeBeforeStartTime
+        case shouldStartSession               /// Indicates that the session should have been started before this action.
+        case shouldStopSession                /// Indicates that the session should have been stopped before this action.
+        case cannotStartTwice                 /// Indicates an attempt to start a session that is already running.
+        case invalidStartAndEndTimes          /// Indicates an inconsistency between the start and end times.
     }
 }

--- a/Sources/SwiftCuckoo/SessionManager.swift
+++ b/Sources/SwiftCuckoo/SessionManager.swift
@@ -7,7 +7,7 @@ public enum SessionManagerError: Error {
 
 /// A protocol that defines the required functionalities for session storage, enabling
 /// asynchronous operations for registering, removing, updating, and retrieving sessions.
-public protocol SessionManagerStorage: AnyActor {
+public protocol SessionManagerStorage: Sendable {
     /// Registers a new session in the storage.
     ///
     /// - Parameter session: The session instance to be registered.

--- a/Sources/SwiftCuckoo/SessionManager.swift
+++ b/Sources/SwiftCuckoo/SessionManager.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A struct responsible for managing time-tracking sessions
+public struct SessionManager: TimeTracking {
+    private init() {}
+
+    /// stores all sessions.
+    static public var sessions: [String: Session] = [:]
+
+    /// Starts or resumes a session for the given task ID.
+    ///
+    /// - Parameter taskID: The unique identifier for the task.
+    /// - Returns: The `Date` representing the start time of the active or resumed session.
+    static public func startTracking(sessionId: Session.Identifier) -> Date {
+        // check if there is an existing session that hasn't ended for a sessionId
+        if let existingSession = SessionManager.sessions[sessionId.rawValue], existingSession.endTime == nil {
+            return existingSession.startTime
+        } else {
+            let session = Session(id: sessionId, startTime: Date())
+            SessionManager.sessions[sessionId.rawValue] = session
+            return session.startTime
+        }
+    }
+}

--- a/Sources/SwiftCuckoo/SessionManager.swift
+++ b/Sources/SwiftCuckoo/SessionManager.swift
@@ -1,24 +1,82 @@
 import Foundation
 
-/// A struct responsible for managing time-tracking sessions
-public struct SessionManager: TimeTracking {
-    private init() {}
+/// Error types for the `SessionManager` related operations.
+public enum SessionManagerError: Error {
+    case cannotStartSessionTwice  /// Indicates an attempt to start a session that is already running.
+}
 
-    /// stores all sessions.
-    static public var sessions: [String: Session] = [:]
-
-    /// Starts or resumes a session for the given task ID.
+/// A protocol that defines the required functionalities for session storage, enabling
+/// asynchronous operations for registering, removing, updating, and retrieving sessions.
+public protocol SessionManagerStorage: AnyActor {
+    /// Registers a new session in the storage.
     ///
-    /// - Parameter taskID: The unique identifier for the task.
+    /// - Parameter session: The session instance to be registered.
+    /// - Throws: An error if the registration fails.
+    func register(session: Session) async throws
+    
+    /// Removes a specific session from the storage.
+    ///
+    /// - Parameter session: The session instance to be removed.
+    /// - Throws: An error if the removal fails.
+    func remove(session: Session) async throws
+    
+    /// Updates an existing session in the storage.
+    ///
+    /// - Parameter session: The session instance with updated details.
+    /// - Throws: An error if the update fails.
+    func update(session: Session) async throws
+    
+    /// Retrieves a session based on its identifier.
+    ///
+    /// - Parameter id: The unique identifier for the session to retrieve.
+    /// - Returns: The session instance if found, or `nil` if not.
+    /// - Throws: An error if the retrieval fails.
+    func session(for id: Session.Identifier) async throws -> Session?
+}
+
+/// A struct responsible for managing time-tracking sessions.
+/// It handles starting, stopping, and retrieving sessions,
+/// leveraging a specified storage mechanism to persist session data.
+public struct SessionManager: TimeTracking {
+    
+    private var sessionManagerStorage: SessionManagerStorage
+    
+    /// Initializes a new instance of `SessionManager` with a specified storage instance.
+    ///
+    /// - Parameter sessionManagerStorage: An instance conforming to `SessionManagerStorage`,
+    ///                                     defaults to `SessionManagerStaticMemoryStorage`.
+    public init(sessionManagerStorage: SessionManagerStorage = SessionManagerStaticMemoryStorage()) {
+        self.sessionManagerStorage = sessionManagerStorage
+    }
+
+    /// Starts or resumes a session for the given session ID.
+    ///
+    /// If there is an existing session corresponding to the session ID, it attempts to start it;
+    /// if not, it creates a new session.
+    ///
+    /// - Parameter sessionId: The unique identifier for the session.
+    /// - Throws: An error of type `SessionManagerError` if there is an attempt
+    ///           to start an already running session.
     /// - Returns: The `Date` representing the start time of the active or resumed session.
-    static public func startTracking(sessionId: Session.Identifier) -> Date {
-        // check if there is an existing session that hasn't ended for a sessionId
-        if let existingSession = SessionManager.sessions[sessionId.rawValue], existingSession.endTime == nil {
-            return existingSession.startTime
-        } else {
-            let session = Session(id: sessionId, startTime: Date())
-            SessionManager.sessions[sessionId.rawValue] = session
-            return session.startTime
+    public func startTracking(sessionId: Session.Identifier) async throws {
+        do {
+            var session = try await self.sessionManagerStorage.session(for: sessionId) ?? Session(id: sessionId)
+            try session.start(on: Date())
+            try await self.sessionManagerStorage.register(session: session)
+        } catch Session.Error.cannotStartTwice {
+            throw SessionManagerError.cannotStartSessionTwice
+        } catch {
+            throw error
         }
+    }
+    
+    /// Retrieves a session by its identifier.
+    ///
+    /// - Parameter sessionId: The unique identifier for the session to retrieve.
+    /// - Returns: An optional `Session`, which will be `nil` if no session is found
+    ///            corresponding to the provided identifier.
+    /// - Throws: An error if the session retrieval fails.
+    public func session(byId sessionId: Session.Identifier) async throws -> Session? {
+        try await sessionManagerStorage.session(for: sessionId)
     }
 }

--- a/Sources/SwiftCuckoo/SessionManagerStaticMemoryStorage.swift
+++ b/Sources/SwiftCuckoo/SessionManagerStaticMemoryStorage.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// An actor responsible for managing session storage in memory.
+/// This implementation is a static in-memory store that provides
+/// concurrent access to session data in a thread-safe manner.
+public actor SessionManagerStaticMemoryStorage: SessionManagerStorage {
+    
+    /// A static dictionary holding sessions, indexed by their identifiers.
+    static var sessions: [Session.Identifier: Session] = [:]
+    
+    /// Initializes a new instance of `SessionManagerStaticMemoryStorage`.
+    public init() {}
+    
+    /// Registers a new session in the static memory storage.
+    ///
+    /// - Parameter session: The `Session` instance to be registered.
+    /// - Throws: An error if the registration process fails.
+    public func register(session: Session) async throws {
+        Self.sessions[session.id] = session
+    }
+    
+    /// Removes a specific session from the static memory storage.
+    ///
+    /// - Parameter session: The `Session` instance to be removed.
+    /// - Throws: An error if the removal process fails.
+    public func remove(session: Session) async throws {
+        Self.sessions.removeValue(forKey: session.id)
+    }
+    
+    /// Updates an existing session in the static memory storage.
+    ///
+    /// - Parameter session: The `Session` instance to be updated with new details.
+    /// - Throws: An error if the update process fails.
+    public func update(session: Session) async throws {
+        Self.sessions[session.id] = session
+    }
+    
+    /// Retrieves a session from the static memory storage by its identifier.
+    ///
+    /// - Parameter id: The unique identifier for the session to retrieve.
+    /// - Returns: The `Session` instance if found, or `nil` if no session
+    ///            exists with the provided identifier.
+    /// - Throws: An error if the retrieval process fails.
+    public func session(for id: Session.Identifier) async throws -> Session? {
+        Self.sessions[id]
+    }
+}

--- a/Sources/SwiftCuckoo/TimeTracking.swift
+++ b/Sources/SwiftCuckoo/TimeTracking.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// A protocol that defines time-tracking functionality for tasks.
+public protocol TimeTracking {
+
+    /// Starts or resumes a session for the given task ID.
+    ///
+    /// - Parameter taskID: The unique identifier for the task.
+    /// - Returns: The `Date` representing the start time of the session.
+    func startTracking(sessionId: Session.Identifier) -> Date
+}

--- a/Sources/SwiftCuckoo/TimeTracking.swift
+++ b/Sources/SwiftCuckoo/TimeTracking.swift
@@ -7,5 +7,5 @@ public protocol TimeTracking {
     ///
     /// - Parameter taskID: The unique identifier for the task.
     /// - Returns: The `Date` representing the start time of the session.
-    func startTracking(sessionId: Session.Identifier) -> Date
+    static func startTracking(sessionId: Session.Identifier) -> Date
 }

--- a/Sources/SwiftCuckoo/TimeTracking.swift
+++ b/Sources/SwiftCuckoo/TimeTracking.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 /// A protocol that defines time-tracking functionality for tasks.
-public protocol TimeTracking {
+public protocol TimeTracking: Sendable {
 
     /// Starts or resumes a session for the given task ID.
     ///
     /// - Parameter taskID: The unique identifier for the task.
     /// - Returns: The `Date` representing the start time of the session.
-    static func startTracking(sessionId: Session.Identifier) -> Date
+    func startTracking(sessionId: Session.Identifier) async throws
 }

--- a/Tests/SwiftCuckooTests/SessionManagerStaticMemoryStorageTests.swift
+++ b/Tests/SwiftCuckooTests/SessionManagerStaticMemoryStorageTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import SwiftCuckoo
+
+private extension Session.Identifier {
+    static let test = Session.Identifier(rawValue: "test")
+}
+
+final class SessionManagerStaticMemoryStorageTests {
+    
+    private let sessionManagerStaticMemoryStorage = SessionManagerStaticMemoryStorage()
+    
+    /// Tests the operations of `SessionManagerStaticMemoryStorage` for registering,
+    /// updating, and removing sessions in sequence, ensuring that the appropriate session
+    /// states are reflected at each step.
+    @Test("Testing operations of SessionManagerStaticMemoryStorage: registering, updating, and removing a session.")
+    func testSessionManagerStaticMemoryStorage_when_registering_updating_and_removing_session() async throws {
+        // Arrange: Create a new session for testing
+        var session = Session(id: .test)
+        
+        // Act: Attempt to retrieve a session that hasn't been registered yet
+        await #expect(
+            try sessionManagerStaticMemoryStorage.session(for: .test) == nil,
+            "The session should not exist before registration."
+        )
+        
+        // Act: Register the session
+        try await sessionManagerStaticMemoryStorage.register(session: session)
+        
+        // Assert: Check if the session status is idle after registration
+        await #expect(
+            try sessionManagerStaticMemoryStorage.session(for: .test)?.status() == .idle,
+            "After registration, the session status should be idle."
+        )
+        
+        // Act: Start the session
+        try session.start()
+        
+        // Act: Update the session in storage
+        try await sessionManagerStaticMemoryStorage.update(session: session)
+        
+        // Assert: Verify that the session status is now running
+        await #expect(
+            try sessionManagerStaticMemoryStorage.session(for: .test)?.status() == .running,
+            "After starting, the session status should be running."
+        )
+        
+        // Act: Remove the session from storage
+        try await sessionManagerStaticMemoryStorage.remove(session: session)
+        
+        // Assert: Ensure that the session has been removed from storage
+        await #expect(
+            try sessionManagerStaticMemoryStorage.session(for: .test) == nil,
+            "The session should be removed from storage."
+        )
+    }
+}

--- a/Tests/SwiftCuckooTests/SessionManagerTests.swift
+++ b/Tests/SwiftCuckooTests/SessionManagerTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+import SwiftCuckoo
+
+private extension Session.Identifier {
+    static let test = Session.Identifier(rawValue: "test")
+    static let test2 = Session.Identifier(rawValue: "test2")
+}
+
+final class SessionManagerTests {
+
+
+    @Test("Test start tracking when session already exists")
+    func testStartTracking_when_session_exists() {
+        let startTime = Date()
+        let session1 = Session(id: .test, startTime: startTime)
+        let session2 = Session(id: .test2, startTime: startTime)
+
+        SessionManager.sessions[Session.Identifier.test.rawValue] = session1
+        SessionManager.sessions[Session.Identifier.test2.rawValue] = session2
+
+        let testSessionStartTime = SessionManager.startTracking(sessionId: .test)
+
+        #expect(testSessionStartTime == session1.startTime)
+        #expect(testSessionStartTime != session2.startTime)
+    }
+
+    @Test("Test start tracking when session doesn't exists")
+    func testStartTracking_when_session_doesnt_exist() {
+        let newSessionDate = SessionManager.startTracking(sessionId: Session.Identifier(rawValue: "New Session"))
+
+        #expect(SessionManager.sessions["New Session"]?.startTime == newSessionDate)
+    }
+}

--- a/Tests/SwiftCuckooTests/SessionManagerTests.swift
+++ b/Tests/SwiftCuckooTests/SessionManagerTests.swift
@@ -1,34 +1,116 @@
 import Foundation
 import Testing
-import SwiftCuckoo
+@testable import SwiftCuckoo
 
 private extension Session.Identifier {
     static let test = Session.Identifier(rawValue: "test")
     static let test2 = Session.Identifier(rawValue: "test2")
 }
 
-final class SessionManagerTests {
-
-
-    @Test("Test start tracking when session already exists")
-    func testStartTracking_when_session_exists() {
-        let startTime = Date()
-        let session1 = Session(id: .test, startTime: startTime)
-        let session2 = Session(id: .test2, startTime: startTime)
-
-        SessionManager.sessions[Session.Identifier.test.rawValue] = session1
-        SessionManager.sessions[Session.Identifier.test2.rawValue] = session2
-
-        let testSessionStartTime = SessionManager.startTracking(sessionId: .test)
-
-        #expect(testSessionStartTime == session1.startTime)
-        #expect(testSessionStartTime != session2.startTime)
+private final actor SessionManagerStorageStub: SessionManagerStorage {
+    
+    var sessions: [Session.Identifier: Session] = [:]
+    
+    private var registerThrowsError: Error?
+    
+    @discardableResult
+    func throwErrorOnRegister(_ error: Error) async -> Self {
+        registerThrowsError = error
+        return self
     }
+    
+    func register(session: SwiftCuckoo.Session) async throws {
+        if let registerThrowsError {
+            throw registerThrowsError
+        }
+        
+        sessions[session.id] = session
+    }
+    
+    func remove(session: SwiftCuckoo.Session) async throws {
+        sessions.removeValue(forKey: session.id)
+    }
+    
+    func update(session: SwiftCuckoo.Session) async throws {
+        sessions[session.id] = session
+    }
+    
+    func session(for id: SwiftCuckoo.Session.Identifier) async throws -> SwiftCuckoo.Session? {
+        sessions[id]
+    }
+}
 
-    @Test("Test start tracking when session doesn't exists")
-    func testStartTracking_when_session_doesnt_exist() {
-        let newSessionDate = SessionManager.startTracking(sessionId: Session.Identifier(rawValue: "New Session"))
+final class SessionManagerTests {
+    private var sessionManagerStorageStub = SessionManagerStorageStub()
+    lazy var sessionManager = SessionManager(sessionManagerStorage: self.sessionManagerStorageStub)
 
-        #expect(SessionManager.sessions["New Session"]?.startTime == newSessionDate)
+    /// Tests starting tracking when the session does not exist, ensuring the session is created.
+    @Test("Starting tracking when session doesn't exist creates the session.")
+    func testStartTracking_when_session_doesnt_exist() async throws {
+        // Arrange: Verify that the session is initially not present
+        await #expect(
+            try sessionManager.session(byId: .test) == nil,
+            "Session with identifier test should not exist at the start."
+        )
+        
+        // Act: Start tracking a new session
+        try? await sessionManager.startTracking(sessionId: .test)
+        
+        // Assert: Verify that the session is now created
+        await #expect(
+            try sessionManager.session(byId: .test) != nil,
+            "Session with identifier test should be present after starting tracking."
+        )
+        
+        // Arrange: Verify that another session does not exist
+        await #expect(
+            try sessionManager.session(byId: .test2) == nil,
+            "Session with identifier test2 should not exist at the start."
+        )
+        
+        // Act: Start tracking a session with a different identifier
+        try? await sessionManager.startTracking(sessionId: .test2)
+        
+        // Assert: Verify that the second session is created
+        await #expect(
+            try sessionManager.session(byId: .test2) != nil,
+            "Session with identifier test2 should be present after starting tracking."
+        )
+    }
+    
+    /// Tests starting tracking on the same session twice to ensure proper error handling.
+    @Test("Attempting to start tracking twice should throw an error.")
+    func testStartTrackingTwice() async throws {
+        // Arrange: Start tracking a session
+        try? await sessionManager.startTracking(sessionId: .test)
+        
+        // Assert: Verify that the session is now created
+        await #expect(try sessionManager.session(byId: .test) != nil,
+                       "Session with identifier test should be present after first start.")
+        
+        // Act & Assert: Attempt to start the same session again and expect an error
+        await #expect(
+            throws: SessionManagerError.cannotStartSessionTwice,
+            "Starting a session that is already running should throw an error.",
+            performing: {
+                try await sessionManager.startTracking(sessionId: .test)
+            }
+        )
+    }
+    
+    /// Tests attempting to start tracking a session when the registration fails.
+    @Test("Starting tracking should fail when registration fails.")
+    func testStartTracking_when_register_fails() async throws {
+        // Arrange: Configure the storage stub to throw an error during registration
+        await sessionManagerStorageStub.throwErrorOnRegister(NSError(domain: "Register Error", code: 1))
+        
+        // Act & Assert: Attempt to start tracking and expect an error
+        await #expect(
+            throws: NSError.self,
+            "Starting a session should throw an error when registration fails.",
+            performing: {
+                try await sessionManager.startTracking(sessionId: .test)
+            }
+        )
     }
 }


### PR DESCRIPTION
**Overview**

This PR  establishes a new protocol that defines time tracking functionality for tasks, currently there is one static func startTracking that returns a Date object. Also a monostate singleton was added to conform to the new protocol which has a static property that should be the single source of truth for tasks 

**Key Changes**

1. `TimeTracking` Protocol:
    - `Session` structure has been added to represent individual time tracking sessions.
2. `SessionManager` Struct
    - Conforms to TimeTracking and implements its methods
    - Contains static property:
      - `sessions`: A dictionary of key type string and value type `Session`
3. Unit Tests for `SessionManager`
    - Added comprehensive tests in `SessionManagerTests.swift` that cover various scenarios, including:
       - Return a Date when a session exists in `SessionManager.sessions`
       - Return a Date when a session doesn't exists in `SessionManager.session`
 