### PR TITLE
Draft: Stop Tracking functionality

### DIFF
--- a/Sources/SwiftCuckoo/TimeTracking.swift
+++ b/Sources/SwiftCuckoo/TimeTracking.swift
@@ -8,4 +8,9 @@ public protocol TimeTracking: Sendable {
     /// - Parameter taskID: The unique identifier for the task.
     /// - Returns: The `Date` representing the start time of the session.
     func startTracking(sessionId: Session.Identifier) async throws
+
+    /// Stops or pauses a session for the given task ID.
+    ///
+    /// - Parameter taskID: The unique identifier for the task.
+    func stopTracking(sessionId: Session.Identifier) async throws
 }

--- a/Tests/SwiftCuckooTests/SessionManagerTests.swift
+++ b/Tests/SwiftCuckooTests/SessionManagerTests.swift
@@ -113,4 +113,31 @@ final class SessionManagerTests {
             }
         )
     }
+
+    /// Tests attempting to stop tracking a session
+    @Test("Stop tracking should not fail")
+    func testStopTracking() async throws {
+        // Arrange: Start tracking a session
+        try await sessionManager.startTracking(sessionId: .test)
+
+        // Assert: Verify that the session is now created
+        await #expect(try sessionManager.session(byId: .test) != nil,
+                       "Session with identifier test should be present after first start.")
+
+        // Arrange: Stop tracking a session
+        try await sessionManager.stopTracking(sessionId: .test)
+
+        // Assert: Verify that the session now has an end time
+        await #expect(try sessionManager.session(byId: .test)?.endTime != nil)
+    }
+
+    /// Test attempting to stop tracking a session that doens't exist
+    @Test("Stop tracking should fail")
+    func testStopTrackingFails() async throws {
+        // Act & Assert: Attempt to stop tracking and expect an error
+        await #expect(
+            throws: SessionManagerError.noSessionRunning, "Trying to stop a session that doesn't exist should throw an error", performing: {
+                try await sessionManager.stopTracking(sessionId: .test2)
+            })
+    }
 }


### PR DESCRIPTION
### Overview
Adding `stopTracking` function to `TimeTracking` to allow a session to stop. Along with this introduces a new error in `SessionManagerError`