### PR TITLE
Initial creation of Lap object, tests still needed

### DIFF
--- a/Sources/SwiftCuckoo/Lap.swift
+++ b/Sources/SwiftCuckoo/Lap.swift
@@ -6,6 +6,12 @@ import Foundation
 /// of a single lap, providing a way to monitor intervals within a task or session.
 public struct Lap: Equatable, Hashable {
 
+    /// Defines the different states of a  `Lap`.
+    public enum LapStatus: Equatable {
+        case active                /// Indicates the lap is active.
+        case inactive              /// Indicates the lap is inactive.
+    }
+
     /// A unique identifier for the lap instance.
     public var id: Identifier
 
@@ -26,13 +32,20 @@ public struct Lap: Equatable, Hashable {
         self.endTime = endTime
     }
 
+    public mutating func start(on date: Date = Date()) throws {
+        guard lapStatus() == .inactive else {
+            throw Error.lapActive
+        }
+        self.startTime = date
+    }
+
     /// Stops the lap at the specified date.
     ///
     /// - Parameter date: The date when the lap ends. Defaults to the current date.
     /// - Throws: An error if the lap has already ended.
     public mutating func stop(on date: Date = Date()) throws {
-        guard self.endTime == nil else {
-            throw Error.lapAlreadyStopped
+        guard lapStatus() == .active else {
+            throw Error.lapNotActive
         }
 
         self.endTime = date
@@ -44,17 +57,22 @@ public struct Lap: Equatable, Hashable {
     /// - Returns: The duration of the lap as a `TimeInterval`.
     public func duration() throws -> TimeInterval {
         guard let endTime else {
-            throw Error.lapNotEnded
+            throw Error.lapActive
         }
 
         return endTime.timeIntervalSince(startTime)
     }
-
-    /// Determines the current status of the lap.
+    
+    /// Determines the current status of a lap.
     ///
-    /// - Returns: A boolean indicating whether the lap is still running or has completed.
-    public func isRunning() -> Bool {
-        return self.endTime == nil
+    /// - Returns: The current status as a `LapStatus` enumerator indicating whether
+    ///   the session is active, or inactive.
+    public func lapStatus() -> LapStatus {
+        guard let endTime else {
+            return .active
+        }
+
+        return .inactive
     }
 }
 
@@ -81,7 +99,7 @@ extension Lap {
 extension Lap {
     /// Error types specific to the `Lap` structure, used for error handling.
     public enum Error: CustomNSError {
-        case lapAlreadyStopped      /// Indicates that the lap has already been stopped.
-        case lapNotEnded            /// Indicates that the lap has not ended.
+        case lapNotActive      /// Indicates that the lap is inactive.
+        case lapActive         /// Indicates that the lap is already active.
     }
 }

--- a/Sources/SwiftCuckoo/Lap.swift
+++ b/Sources/SwiftCuckoo/Lap.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// A model representing an individual lap within a session.
+///
+/// The `Lap` structure tracks the start time, end time, and calculates the duration
+/// of a single lap, providing a way to monitor intervals within a task or session.
+public struct Lap: Equatable, Hashable {
+
+    /// The start time of the lap.
+    public var startTime: Date
+
+    /// The optional end time of the lap. Defaults to `nil` if the lap is ongoing.
+    public var endTime: Date?
+
+    /// Initializes a new lap instance with a specified start time and an optional end time.
+    ///
+    /// - Parameters:
+    ///   - startTime: The start time of the lap.
+    ///   - endTime: The end time of the lap. Defaults to `nil` for ongoing laps.
+    public init(startTime: Date, endTime: Date? = nil) {
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+
+    /// Stops the lap at the specified date.
+    ///
+    /// - Parameter date: The date when the lap ends. Defaults to the current date.
+    /// - Throws: An error if the lap has already ended.
+    public mutating func stop(on date: Date = Date()) throws {
+        guard self.endTime == nil else {
+            throw Error.lapAlreadyStopped
+        }
+
+        self.endTime = date
+    }
+
+    /// Calculates the duration of the lap.
+    ///
+    /// - Throws: An error if the lap has not ended.
+    /// - Returns: The duration of the lap as a `TimeInterval`.
+    public func duration() throws -> TimeInterval {
+        guard let endTime else {
+            throw Error.lapNotEnded
+        }
+
+        return endTime.timeIntervalSince(startTime)
+    }
+
+    /// Determines the current status of the lap.
+    ///
+    /// - Returns: A boolean indicating whether the lap is still running or has completed.
+    public func isRunning() -> Bool {
+        return self.endTime == nil
+    }
+}
+
+// MARK: - Lap Errors
+
+extension Lap {
+    /// Error types specific to the `Lap` structure, used for error handling.
+    public enum Error: CustomNSError {
+        case lapAlreadyStopped      /// Indicates that the lap has already been stopped.
+        case lapNotEnded            /// Indicates that the lap has not ended.
+    }
+}

--- a/Sources/SwiftCuckoo/Lap.swift
+++ b/Sources/SwiftCuckoo/Lap.swift
@@ -6,6 +6,9 @@ import Foundation
 /// of a single lap, providing a way to monitor intervals within a task or session.
 public struct Lap: Equatable, Hashable {
 
+    /// A unique identifier for the lap instance.
+    public var id: Identifier
+
     /// The start time of the lap.
     public var startTime: Date
 
@@ -17,7 +20,8 @@ public struct Lap: Equatable, Hashable {
     /// - Parameters:
     ///   - startTime: The start time of the lap.
     ///   - endTime: The end time of the lap. Defaults to `nil` for ongoing laps.
-    public init(startTime: Date, endTime: Date? = nil) {
+    public init(id: Identifier, startTime: Date, endTime: Date? = nil) {
+        self.id = id
         self.startTime = startTime
         self.endTime = endTime
     }
@@ -51,6 +55,24 @@ public struct Lap: Equatable, Hashable {
     /// - Returns: A boolean indicating whether the lap is still running or has completed.
     public func isRunning() -> Bool {
         return self.endTime == nil
+    }
+}
+
+// MARK: - Identifier
+
+extension Lap {
+    /// A unique identifier for the session, conforming to `RawRepresentable`,
+    /// `Equatable`, and `Hashable` protocols for easy management and comparison.
+    public struct Identifier: RawRepresentable, Equatable, Hashable {
+        /// The raw string value representing the identifier.
+        public let rawValue: String
+
+        /// Initializes a new identifier with the specified raw value.
+        ///
+        /// - Parameter rawValue: The string value that represents the identifier.
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
     }
 }
 

--- a/Sources/SwiftCuckoo/Lap.swift
+++ b/Sources/SwiftCuckoo/Lap.swift
@@ -16,7 +16,7 @@ public struct Lap: Equatable, Hashable {
     public var id: Identifier
 
     /// The start time of the lap.
-    public var startTime: Date
+    public var startTime: Date?
 
     /// The optional end time of the lap. Defaults to `nil` if the lap is ongoing.
     public var endTime: Date?
@@ -26,7 +26,7 @@ public struct Lap: Equatable, Hashable {
     /// - Parameters:
     ///   - startTime: The start time of the lap.
     ///   - endTime: The end time of the lap. Defaults to `nil` for ongoing laps.
-    public init(id: Identifier, startTime: Date, endTime: Date? = nil) {
+    public init(id: Identifier, startTime: Date? = nil, endTime: Date? = nil) {
         self.id = id
         self.startTime = startTime
         self.endTime = endTime
@@ -58,6 +58,10 @@ public struct Lap: Equatable, Hashable {
     public func duration() throws -> TimeInterval {
         guard let endTime else {
             throw Error.lapActive
+        }
+
+        guard let startTime else {
+            throw Error.lapNotActive
         }
 
         return endTime.timeIntervalSince(startTime)

--- a/Tests/SwiftCuckooTests/LapTests.swift
+++ b/Tests/SwiftCuckooTests/LapTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+@testable import SwiftCuckoo
+
+private extension Lap.Identifier {
+    static let lapTest = Lap.Identifier(rawValue: "lapTest")
+}
+
+final class LapTests {
+
+    /// Tests that starting a lap sets the start time
+    @Test("Start lap should start time")
+    func testStartLap() throws {
+        // Arrange: Create a lap object with a defined start time
+        let startTime: Date = .distantPast
+        var lap = Lap(id: .lapTest, startTime: startTime)
+
+        // Act: Start the lap
+        try lap.start(on: startTime)
+
+        // Assert: Verify that lap time is set
+        #expect(
+            lap.startTime == startTime,
+            "The lap's start time should be set to provided start time")
+    }
+
+    /// Test that starting a lap twice will throw an error
+    @Test("Starting a lap twice should throw an error")
+    func testStartingLapTwiceThrowsError() throws {
+
+        // Arrange: Create new lap
+        var lap = Lap(id: .lapTest, startTime: .now)
+        try lap.start()
+
+        // Act & Assert: Attempt to start the lap again and expect an error
+        #expect(
+            throws: Lap.Error.lapActive,
+            "Starting a lap that is already active should throw an error",
+            performing: {
+                try lap.start()
+            }
+        )
+    }
+
+    /// Test that stopping a lap that hasn't started will throw an error
+    @Test("Stopping a lap that hasn't started should throw an error")
+    func testStoppingInactiveLapThrowsError() throws {
+
+        // Arrange: Create new lap
+        var lap = Lap(id: .lapTest, startTime: .now)
+
+        // Act & Assert: Attempt to start the lap again and expect an error
+        #expect(
+            throws: Lap.Error.lapNotActive,
+            "Starting a lap that is already active should throw an error",
+            performing: {
+                try lap.stop()
+            }
+        )
+    }
+
+    /// Tests that stopping a lap sets the stop time
+    @Test("Stop lap should set end time")
+    func testStopLap() throws {
+        // Arrange: Create a lap object and a defined end time
+        let endTime: Date = .distantFuture
+        var lap = Lap(id: .lapTest, startTime: .now)
+        try lap.start()
+
+        // Act: Stop the lap
+        try lap.stop(on: endTime)
+
+
+        // Assert: Verify that lap time is set
+        #expect(
+            lap.endTime == endTime,
+            "The lap's end time should be set to provided end time")
+        #expect(
+            lap.endTime != nil,
+            "The lap's end time should not be nil")
+    }
+
+    /// Tests that requesting the duration of a lap without starting one throws an error.
+    @Test("Requesting duration without starting a lap should throw a lap not active error.")
+    func testDurationWithoutStartTimeShouldThrowError() throws {
+        // Arrange: Create a new lap without starting it
+        let lap = Lap(id: .lapTest)
+
+        // Act & Assert: Attempt to get the duration and expect an error
+        #expect(
+            throws: Lap.Error.lapNotActive,
+            "Duration should not be calculable if the lap has not started.",
+            performing: {
+                try lap.duration()
+            }
+        )
+    }
+
+    /// Tests that requesting the duration of a lap without ending one throws an error.
+    @Test("Requesting duration without ending a lap should throw a lap still active error.")
+    func testDurationWithoutEndTimeShouldThrowError() throws {
+        // Arrange: Create a new lap without starting it
+        var lap = Lap(id: .lapTest)
+        try lap.start(on: .now)
+
+        // Act & Assert: Attempt to get the duration and expect an error
+        #expect(
+            throws: Lap.Error.lapActive,
+            "Duration should not be calculable if the lap has not ended.",
+            performing: {
+                try lap.duration()
+            }
+        )
+    }
+
+    /// Tests that requesting the duration from a valid lap returns the correct duration
+    @Test("Request duration with a lap that has a start and end time should return the correct duration")
+    func testDurationWithValidLap() throws {
+        // Arrange: Create new lap object, then start and end it
+        var lap = Lap(id: .lapTest)
+        try lap.start(on: .now)
+        try lap.stop(on: .distantFuture)
+
+        // Act: Calculate the duration of the lap
+        let duration = try lap.duration()
+
+        // Assert: Very that the duration is greater than zero
+        #expect(
+            duration > 0,
+            "The duration should be greater than zero"
+        )
+    }
+}

--- a/Tests/SwiftCuckooTests/LapTests.swift
+++ b/Tests/SwiftCuckooTests/LapTests.swift
@@ -2,10 +2,6 @@ import Foundation
 import Testing
 @testable import SwiftCuckoo
 
-private extension Lap.Identifier {
-    static let lapTest = Lap.Identifier(rawValue: "lapTest")
-}
-
 final class LapTests {
 
     /// Tests that starting a lap sets the start time
@@ -13,7 +9,7 @@ final class LapTests {
     func testStartLap() throws {
         // Arrange: Create a lap object with a defined start time
         let startTime: Date = .distantPast
-        var lap = Lap(id: .lapTest, startTime: startTime)
+        var lap = Lap(startTime: startTime)
 
         // Act: Start the lap
         try lap.start(on: startTime)
@@ -29,12 +25,12 @@ final class LapTests {
     func testStartingLapTwiceThrowsError() throws {
 
         // Arrange: Create new lap
-        var lap = Lap(id: .lapTest, startTime: .now)
+        var lap = Lap(startTime: .now)
         try lap.start()
 
         // Act & Assert: Attempt to start the lap again and expect an error
         #expect(
-            throws: Lap.Error.lapActive,
+            throws: Lap.Error.lapAlreadyStarted,
             "Starting a lap that is already active should throw an error",
             performing: {
                 try lap.start()
@@ -47,11 +43,11 @@ final class LapTests {
     func testStoppingInactiveLapThrowsError() throws {
 
         // Arrange: Create new lap
-        var lap = Lap(id: .lapTest, startTime: .now)
+        var lap = Lap(startTime: .now)
 
         // Act & Assert: Attempt to start the lap again and expect an error
         #expect(
-            throws: Lap.Error.lapNotActive,
+            throws: Lap.Error.tryingStopNonStartedLap,
             "Starting a lap that is already active should throw an error",
             performing: {
                 try lap.stop()
@@ -64,7 +60,7 @@ final class LapTests {
     func testStopLap() throws {
         // Arrange: Create a lap object and a defined end time
         let endTime: Date = .distantFuture
-        var lap = Lap(id: .lapTest, startTime: .now)
+        var lap = Lap(startTime: .now)
         try lap.start()
 
         // Act: Stop the lap
@@ -84,11 +80,11 @@ final class LapTests {
     @Test("Requesting duration without starting a lap should throw a lap not active error.")
     func testDurationWithoutStartTimeShouldThrowError() throws {
         // Arrange: Create a new lap without starting it
-        let lap = Lap(id: .lapTest)
+        let lap = Lap()
 
         // Act & Assert: Attempt to get the duration and expect an error
         #expect(
-            throws: Lap.Error.lapNotActive,
+            throws: Lap.Error.tryingStopNonStartedLap,
             "Duration should not be calculable if the lap has not started.",
             performing: {
                 try lap.duration()
@@ -100,12 +96,12 @@ final class LapTests {
     @Test("Requesting duration without ending a lap should throw a lap still active error.")
     func testDurationWithoutEndTimeShouldThrowError() throws {
         // Arrange: Create a new lap without starting it
-        var lap = Lap(id: .lapTest)
+        var lap = Lap()
         try lap.start(on: .now)
 
         // Act & Assert: Attempt to get the duration and expect an error
         #expect(
-            throws: Lap.Error.lapActive,
+            throws: Lap.Error.lapAlreadyStarted,
             "Duration should not be calculable if the lap has not ended.",
             performing: {
                 try lap.duration()
@@ -117,7 +113,7 @@ final class LapTests {
     @Test("Request duration with a lap that has a start and end time should return the correct duration")
     func testDurationWithValidLap() throws {
         // Arrange: Create new lap object, then start and end it
-        var lap = Lap(id: .lapTest)
+        var lap = Lap()
         try lap.start(on: .now)
         try lap.stop(on: .distantFuture)
 


### PR DESCRIPTION
#### Overview
This pull request introduces a new time tracking functionality to the `SwiftCuckoo` project by implementing a `Lap` struct that can encapsulate lap details about time-tracked tasks. The model includes properties for start time, optional end time, and a method to calculate the duration of the session. Additionally, unit tests have will be added 

#### Key Changes
1. **New `Lap` Struct**:
   - A `Session` structure has been added to represent individual laps.
   - Contains properties:
     - `id`: A unique identifier for the session.
     - `startTime`: The time the session begins.
     - `endTime`: An optional property representing when the session ends.
   - Implements a method `duration()` that calculates the time elapsed between `startTime` and `endTime`.
   - Has Errors as well


