### PR TITLE
Session lap tracking

### DIFF
--- a/Sources/SwiftCuckoo/Session.swift
+++ b/Sources/SwiftCuckoo/Session.swift
@@ -32,6 +32,10 @@ public struct Session: Equatable, Hashable {
     /// was completed or could still be ongoing.
     public var endTime: Date?
 
+    /// Array of `Lap` which stores lap information
+    // TODO: Maybe fix docC
+    private(set) var laps: [Lap]
+
     /// Initializes a new session instance with a unique identifier and an optional start time.
     ///
     /// - Parameters:
@@ -44,6 +48,7 @@ public struct Session: Equatable, Hashable {
         self.id = id
         self.startTime = nil
         self.endTime = nil
+        self.laps = []
     }
     
     /// Starts the session at the specified date.
@@ -115,6 +120,60 @@ public struct Session: Equatable, Hashable {
         
         return .completed
     }
+
+    // MARK: - Session Lap Functions
+
+    /// Retrieves a specific lap based on its index in the collection.
+    ///
+    /// This function returns the lap at the specified index in the `laps` collection.
+    ///
+    /// - Parameter id: The index of the lap to be retrieved, starting from `0` for the first lap.
+    /// - Returns: An optional `Lap` instance. If the index is valid (within the range of the `laps` collection), it returns the `Lap` object; otherwise, returns `nil`.
+    public func getLap(id: Int) -> Lap? {
+        guard id >= 0 && id < laps.count else {
+            return nil
+        }
+        return laps[id]
+    }
+
+    /// Adds a new lap to the session and starts it.
+    ///
+    /// This function creates a new `Lap` instance with the current time as the start time. It attempts to start the lap, and if successful, appends it to the `laps` collection and returns the `Lap` instance.
+    ///
+    /// - Throws:
+    ///     - `Error.lapAlreadyStarted`: If the lap is already started. Although this scenario is unlikely since a new lap is created, the error is still handled for safety.
+    /// - Returns: The newly added `Lap` instance.
+    public mutating func addLap() throws -> Lap {
+        var lap = Lap(startTime: Date())
+
+        do {
+            try lap.start()
+        } catch Lap.Error.lapAlreadyStarted {
+            throw Error.lapAlreadyStarted
+        }
+
+        self.laps.append(lap)
+        return lap
+    }
+
+    /// Stops an existing lap based on the provided index.
+    ///
+    /// This function attempts to retrieve a lap at the specified index and stop it. If the lap has not been started yet,
+    /// an error will be thrown indicating that the lap cannot be stopped.
+    ///
+    /// - Parameter id: The index of the lap to be stopped, starting from `0` for the first lap.
+    /// - Throws:
+    ///     - `Error.tryingStopNonStartedLap`: If the function attempts to stop a lap that has not been started.
+    /// - Note: If the lap does not exist at the given index, this function will do nothing, as the `getLap(id:)` function returns `nil`.
+    public mutating func stopLap(id: Int) throws {
+        var lap = getLap(id: id)
+
+        do {
+            try lap?.stop()
+        } catch Lap.Error.tryingStopNonStartedLap {
+            throw Error.tryingStopNonStartedLap
+        }
+    }
 }
 
 // MARK: - Identifier
@@ -145,5 +204,7 @@ extension Session {
         case shouldStopSession                /// Indicates that the session should have been stopped before this action.
         case cannotStartTwice                 /// Indicates an attempt to start a session that is already running.
         case invalidStartAndEndTimes          /// Indicates an inconsistency between the start and end times.
+        case lapAlreadyStarted                /// Indicates that the session is unable to start/add a lap
+        case tryingStopNonStartedLap          /// Indicates that the session is unable to stop the lap
     }
 }

--- a/Sources/SwiftCuckoo/Session.swift
+++ b/Sources/SwiftCuckoo/Session.swift
@@ -33,7 +33,6 @@ public struct Session: Equatable, Hashable {
     public var endTime: Date?
 
     /// Array of `Lap` which stores lap information
-    // TODO: Maybe fix docC
     private(set) var laps: [Lap]
 
     /// Initializes a new session instance with a unique identifier and an optional start time.

--- a/Tests/SwiftCuckooTests/SessionTests.swift
+++ b/Tests/SwiftCuckooTests/SessionTests.swift
@@ -167,4 +167,85 @@ final class SessionTests {
             }
         )
     }
+
+    /// Test that requesting to add a lap to a session is successful
+    @Test("Test that a session is able to start a lap")
+    func testSessionCanStartLap() throws {
+        // Arrange
+        var session = Session(id: .test)
+        try session.start()
+
+        // Act: Attempt to start and add a lap
+        var lap = try session.addLap()
+
+        // Assert: verify that the laps start time exists
+        #expect(
+            lap.startTime != nil,
+            "laps start time should not be nil"
+        )
+        #expect(
+            session.laps.count < 0,
+            "Session should have at least one lap"
+        )
+    }
+
+    /// Test that requesting to stop a lap to a session is successful
+    @Test("Test that a session is able to stop a lap")
+    func testSessionCanStopLap() throws {
+        // Arrange
+        var session = Session(id: .test)
+        try session.start()
+        var lap = try session.addLap()
+        let endTime: Date = .distantFuture
+
+        // Act: Attempt to stop a lap
+        try lap.stop(on: endTime)
+
+
+        // Assert: verify that the laps start time exists
+        #expect(
+            lap.endTime == endTime,
+            "laps start time should not be nil"
+        )
+    }
+
+    /// Test that requesting to stop a lap twice should throw an error
+    @Test("Test that a session is not able to stop a lap twice")
+    func testSessionCantStopLapTwice() throws {
+        // Arrange
+        var session = Session(id: .test)
+        try session.start()
+        var lap = try session.addLap()
+        let endTime: Date = .distantFuture
+
+        // Act: Attempt to stop a lap
+        try lap.stop(on: endTime)
+
+        #expect(
+            throws: Session.Error.tryingStopNonStartedLap,
+            "Stopping a lap twice should fail",
+            performing: {
+                try lap.stop()
+            }
+        )
+    }
+
+    /// Test that retrieving a lap will be successful
+    @Test("Test that a session able to retrieve a lap")
+    func testSessionGetLap() throws {
+        // Arrange
+        var session = Session(id: .test)
+        try session.start()
+        _ = try session.addLap()
+        _ = try session.addLap()
+
+
+        // Act: Attempt to stop a lap
+        let firstLap = session.getLap(id: 0)
+
+        #expect(
+            firstLap != nil,
+            "Calling get lap will return a lap"
+        )
+    }
 }


### PR DESCRIPTION
#### Overview
This pull request introduces new functions into `Session` for starting, stopping, and tracking of laps

#### Key Changes
1. New private Array of `Lap`
2. New `getLap(id: Int)` function:
   - This function returns the lap at the specified index in the `laps` collection
2. New `addLap()` function:
   - This function initiates an instance of `Lap` then starts the lap and returns that instance
3. New `stopLap(id: Int)` function:
   - This function stop an `Lap` from the given index
 
   